### PR TITLE
Upgrade actions/setup-go to v2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
-    - uses: actions/setup-go@v2-beta
+    - uses: actions/setup-go@v2
       with:
         go-version: ${{ matrix.go }}
     - run: go test ./...


### PR DESCRIPTION
Because [`set-env` has been deprecated](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/), CI is failing in actions/setup-go@v2-beta.
Upgrading to actions/setup-go@v2 fixes this.
